### PR TITLE
Add setFirebaseId method to IAPKit and fetchers

### DIFF
--- a/Sources/IAPKit/IAPFetchers/AdaptyFetcher.swift
+++ b/Sources/IAPKit/IAPFetchers/AdaptyFetcher.swift
@@ -197,6 +197,15 @@ final class AdaptyFetcher: NSObject, IAPProductFetchable {
             )
         }
     }
+    
+    func setFirebaseId(_ id: String?) {
+        Task {
+            try? await Adapty.setIntegrationIdentifier(
+                key: "firebase_app_instance_id",
+                value: id ?? ""
+            )
+        }
+    }
 }
 
 public struct IAPProfile {

--- a/Sources/IAPKit/IAPFetchers/IAPProductFetcher.swift
+++ b/Sources/IAPKit/IAPFetchers/IAPProductFetcher.swift
@@ -100,4 +100,8 @@ final class IAPProductFetcher {
     func setPlayerId(_ playerId: String?) {
         adaptyFetcher.setPlayerId(playerId)
     }
+    
+    func setFirebaseId(_ id: String?) {
+        adaptyFetcher.setFirebaseId(id)
+    }
 }

--- a/Sources/IAPKit/IAPKit.swift
+++ b/Sources/IAPKit/IAPKit.swift
@@ -62,6 +62,10 @@ public final class IAPKit: NSObject {
     public func setPlayerId(_ playerId: String?) {
         productFetcher.setPlayerId(playerId)
     }
+    
+    public func setFirebaseId(_ id: String?) {
+        productFetcher.setFirebaseId(id)
+    }
 
     public func restorePurchases(completion: @escaping ((Result<Bool, Error>) -> Void)) {
         productFetcher.restorePurchases(completion: completion)


### PR DESCRIPTION
Introduces a setFirebaseId method to IAPKit, IAPProductFetcher, and AdaptyFetcher, allowing the Firebase App Instance ID to be set and integrated with Adapty. This enables tracking or integration scenarios requiring the Firebase identifier.