### PR TITLE
Update AdaptySDK-iOS to version 3.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/adaptyteam/AdaptySDK-iOS", exact: "3.8.0"),
+        .package(url: "https://github.com/adaptyteam/AdaptySDK-iOS", exact: "3.11.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift", from: "6.6.0"),
     ],
     targets: [


### PR DESCRIPTION
Bump AdaptySDK-iOS dependency from 3.8.0 to 3.11.0 in Package.swift to use the latest features and fixes.